### PR TITLE
Fix page crashing on refresh

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
 import {
-  createBrowserRouter,
+  createHashRouter,
   RouterProvider,
 } from "react-router-dom";
 
@@ -25,7 +25,7 @@ function EmptyChild() {
 
 const userId = window.location.pathname.split('/')[1];
 const basename = userId ? `/${userId}` : '/';
-const router = createBrowserRouter([
+const router = createHashRouter([
   {
     path: "/",
     element: <App />,


### PR DESCRIPTION
Closes #38 

fixed the bug where the app would crash if you refreshed on a problem page by using hash router instead of browser router