### PR TITLE
Bug fix mutation coding

### DIFF
--- a/src/components/MutationQuestion.tsx
+++ b/src/components/MutationQuestion.tsx
@@ -36,26 +36,24 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
   // The progress bar for mutations
   const countPassedMutants = () => {
     const mutantResults = new Map<number, Set<boolean>>();
-    const rightOutputs = new Map<number, boolean>();
 
     if(evalResponse == null || evalResponse.report[0].mutations == null) return 0
 
-    evalResponse?.report?.forEach((row:any) => {
-      const rightOutput = row.solution.actual[0] === row.expected[0];
+    evalResponse?.report?.forEach((row:any, rowNum:number) => {
 
-      row.mutations.forEach((mutation:any, index:number) => {
-        if (!mutantResults.has(index)) {
-          mutantResults.set(index, new Set());
-        }
-        mutantResults.get(index)!.add(mutation.equal);
-        if (!rightOutputs.has(index)) rightOutputs.set(index, rightOutput);
-    
-      });
+      if(row.solution.actual[0] === row.expected[0]){
+        row.mutations.forEach((mutation:any, index:number) => {
+          if (!mutantResults.has(index)) {
+            mutantResults.set(index, new Set());
+          }
+          mutantResults.get(index)!.add(mutation.equal);  
+        });
+      }
     });
 
     let count = 0;
     mutantResults.forEach((resultSet, index) => {
-      if (resultSet.has(true) && resultSet.has(false) && rightOutputs.get(index)) {
+      if (resultSet.has(true) && resultSet.has(false)) {
         count++;
       }
     });

--- a/src/components/MutationQuestion.tsx
+++ b/src/components/MutationQuestion.tsx
@@ -38,7 +38,7 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
     const mutantResults = new Map<number, Set<boolean>>();
     const rightOutputs = new Map<number, boolean>();
 
-    if(!evalResponse?.report?.length) return 0
+    if(evalResponse?.report?.length) return 0
 
     evalResponse?.report?.forEach((row:any) => {
       const rightOutput = row.actual === row.expected;

--- a/src/components/MutationQuestion.tsx
+++ b/src/components/MutationQuestion.tsx
@@ -38,10 +38,10 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
     const mutantResults = new Map<number, Set<boolean>>();
     const rightOutputs = new Map<number, boolean>();
 
-    if(evalResponse?.report?.length) return 0
+    if(evalResponse == null || evalResponse.report[0].mutations == null) return 0
 
     evalResponse?.report?.forEach((row:any) => {
-      const rightOutput = row.actual === row.expected;
+      const rightOutput = row.solution.actual[0] === row.expected[0];
 
       row.mutations.forEach((mutation:any, index:number) => {
         if (!mutantResults.has(index)) {

--- a/src/components/MutationQuestion.tsx
+++ b/src/components/MutationQuestion.tsx
@@ -36,7 +36,7 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
   // The progress bar for mutations
   const countPassedMutants = () => {
     const mutantResults = new Map<number, Set<boolean>>();
-    const rightOuputs = new Map<number, boolean>();
+    const rightOutputs = new Map<number, boolean>();
 
     if(!evalResponse?.report?.length) return 0
 
@@ -48,14 +48,14 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
           mutantResults.set(index, new Set());
         }
         mutantResults.get(index)!.add(mutation.equal);
-        if (!rightOuputs.has(index)) rightOuputs.set(index, rightOutput);
+        if (!rightOutputs.has(index)) rightOutputs.set(index, rightOutput);
     
       });
     });
 
     let count = 0;
     mutantResults.forEach((resultSet, index) => {
-      if (resultSet.has(true) && resultSet.has(false) && rightOuputs.get(index)) {
+      if (resultSet.has(true) && resultSet.has(false) && rightOutputs.get(index)) {
         count++;
       }
     });

--- a/src/components/MutationQuestion.tsx
+++ b/src/components/MutationQuestion.tsx
@@ -41,7 +41,7 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
 
     evalResponse?.report?.forEach((row:any, rowNum:number) => {
 
-      if(row.solution.actual[0] === row.expected[0]){
+      if(row.solution.equal){
         row.mutations.forEach((mutation:any, index:number) => {
           if (!mutantResults.has(index)) {
             mutantResults.set(index, new Set());

--- a/src/components/MutationQuestion.tsx
+++ b/src/components/MutationQuestion.tsx
@@ -35,7 +35,7 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
   const countPassedMutants = () => {
     const mutantResults = new Map<number, Set<boolean>>();
 
-    if(evalResponse == null || evalResponse.mutants == null) return 0
+    if(evalResponse == null || evalResponse.report[0].mutations == null) return 0
 
     evalResponse?.report?.forEach((row:any) => {
       row.mutations.forEach((mutation:any, index:number) => {

--- a/src/components/MutationQuestion.tsx
+++ b/src/components/MutationQuestion.tsx
@@ -7,7 +7,6 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
   const maxNumberOfRows = 15;
   const numOfMutations = problem.mutations.length;
   const inputCount = problem.io[0].input.length;
-  const outputCount = 1;
 
   //The inputRows are 2D arrays since each row is a test and each test contains 
   //an array of inputs
@@ -36,7 +35,7 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
   const countPassedMutants = () => {
     const mutantResults = new Map<number, Set<boolean>>();
 
-    if(evalResponse == null) return 0
+    if(evalResponse == null || evalResponse.mutants == null) return 0
 
     evalResponse?.report?.forEach((row:any) => {
       row.mutations.forEach((mutation:any, index:number) => {

--- a/src/components/MutationQuestion.tsx
+++ b/src/components/MutationQuestion.tsx
@@ -33,29 +33,32 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
   }, [inputCount, problem.meta.name])
 
 
+  // The progress bar for mutations
   const countPassedMutants = () => {
     const mutantResults = new Map<number, Set<boolean>>();
-    const expects = [];
+    const rightOuputs = new Map<number, boolean>();
 
     if(!evalResponse?.report?.length) return 0
 
     evalResponse?.report?.forEach((row:any) => {
-      row.actual === row.expected ? expects.push(true) : expects.push(false)
+      const rightOutput = row.actual === row.expected;
+
       row.mutations.forEach((mutation:any, index:number) => {
         if (!mutantResults.has(index)) {
           mutantResults.set(index, new Set());
         }
         mutantResults.get(index)!.add(mutation.equal);
+        if (!rightOuputs.has(index)) rightOuputs.set(index, rightOutput);
+    
       });
     });
 
     let count = 0;
     mutantResults.forEach((resultSet, index) => {
-      if (resultSet.has(true) && resultSet.has(false)) {
+      if (resultSet.has(true) && resultSet.has(false) && rightOuputs.get(index)) {
         count++;
       }
     });
-
     return count;
   };
 

--- a/src/components/MutationQuestion.tsx
+++ b/src/components/MutationQuestion.tsx
@@ -32,12 +32,15 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
     setExpectedRows([''])
   }, [inputCount, problem.meta.name])
 
+
   const countPassedMutants = () => {
     const mutantResults = new Map<number, Set<boolean>>();
+    const expects = [];
 
-    if(evalResponse == null || evalResponse.report[0].mutations == null) return 0
+    if(!evalResponse?.report?.length) return 0
 
     evalResponse?.report?.forEach((row:any) => {
+      row.actual === row.expected ? expects.push(true) : expects.push(false)
       row.mutations.forEach((mutation:any, index:number) => {
         if (!mutantResults.has(index)) {
           mutantResults.set(index, new Set());
@@ -47,7 +50,7 @@ export default function MutationQuestion({runCode, inputs, setInput, evalRespons
     });
 
     let count = 0;
-    mutantResults.forEach(resultSet => {
+    mutantResults.forEach((resultSet, index) => {
       if (resultSet.has(true) && resultSet.has(false)) {
         count++;
       }

--- a/src/index.css
+++ b/src/index.css
@@ -66,12 +66,12 @@ code {
   animation: fadeIt 1.2s ease-in-out; 
 }
 
-thead tr{
+.mutation-table thead tr{
   border-bottom: 4px solid black;
   background-color: rgb(18, 148, 160);
 }
 
-.mutation-table table tr:nth-child(odd) td{
+.mutation-table tr:nth-child(odd) td{
   background-color: rgb(131, 218, 225);
 }
 


### PR DESCRIPTION
Related to issue #68 

- Fix bug where if you solve a coding question and switch to a mutation question, the evalResponse is passed to the new question but crashes for it has no mutations
- Add to question progress if the solution and given output are the same