### PR TITLE
Fix crashing when opening the reflection card

### DIFF
--- a/src/components/profile/reflections/Reflections.tsx
+++ b/src/components/profile/reflections/Reflections.tsx
@@ -67,7 +67,12 @@ export default function Reflections({ reflections }: { reflections: Reflection[]
 
                   {isOpen && reflection.code && (
                     <Box component="pre" sx={{mt: 1, p: 1, bgcolor: '#f5f5f5', borderRadius: 1, fontSize: '0.85rem', overflowX: 'auto', }}>
-                      {reflection.code}
+                      {
+                        "code" in reflection.code ? reflection.code.code :
+                        reflection.code.map((c, i) => (
+                          `Input ${++i}: ${c.Input}\t\t Output: ${c.Expected}\n`
+                        ))
+                      }
                     </Box>
                   )}
                 </Stack>

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,12 @@ export type Progress = {
 export type Reflection = {
     category: string;
     problem_title: string;
-    code: string;
+    code: {
+        code: string;
+    } | {
+        Input: string[];
+        Expected: string;
+    }[];
     reflection: string | {
         question: string;
         answer: string;


### PR DESCRIPTION
changing the code type in the database to json broke the way the reflection code is displayed in the profile, so now it displays differently if its a coding or mutation question.